### PR TITLE
Optionally tie pulsar term phase to Earth term phase

### DIFF
--- a/src/enterprise_gwecc.py
+++ b/src/enterprise_gwecc.py
@@ -233,12 +233,19 @@ def gwecc_block(
     lp=Uniform(0, 2 * np.pi),
     log10_A=Uniform(-11, -7)("gwecc_log10_A"),
     psrTerm=False,
+    tie_psrTerm=False,
     spline=False,
     name="gwecc",
 ):
     """Deterministic eccentric-orbit continuous GW model."""
 
-    gammap, lp = (gammap, lp) if psrTerm else (0.0, 0.0)
+    if not psrTerm:
+        # These are not used.
+        gammap, lp = (0.0, 0.0)
+    elif tie_psrTerm:
+        # Tie pulsar term phase to the earth term phase.
+        # This ignores the explicitly given gammap and lp
+        gammap, lp = (gamma0, l0)
 
     return Deterministic(
         eccentric_pta_signal(
@@ -279,12 +286,19 @@ def gwecc_target_block(
     lp=Uniform(0, 2 * np.pi),
     log10_A=Uniform(-11, -7)("gwecc_log10_A"),
     psrTerm=False,
+    tie_psrTerm=False,
     spline=False,
     name="gwecc",
 ):
     """Deterministic eccentric-orbit continuous GW model."""
-
-    gammap, lp = (gammap, lp) if psrTerm else (0.0, 0.0)
+    
+    if not psrTerm:
+        # These are not used.
+        gammap, lp = (0.0, 0.0)
+    elif tie_psrTerm:
+        # Tie pulsar term phase to the earth term phase.
+        # This ignores the explicitly given gammap and lp
+        gammap, lp = (gamma0, l0)
 
     return Deterministic(
         eccentric_pta_signal_target(

--- a/src/enterprise_gwecc.py
+++ b/src/enterprise_gwecc.py
@@ -291,7 +291,7 @@ def gwecc_target_block(
     name="gwecc",
 ):
     """Deterministic eccentric-orbit continuous GW model."""
-    
+
     if not psrTerm:
         # These are not used.
         gammap, lp = (0.0, 0.0)

--- a/test/test_enterprise_gwecc.py
+++ b/test/test_enterprise_gwecc.py
@@ -143,11 +143,8 @@ def test_gwecc_block(psr, psrTerm, tie_psrTerm, spline):
 
     pta = PTA([model(psr)])
 
-    if psrTerm:
-        assert len(pta.param_names) == (13 if tie_psrTerm else 11)
-    else:
-        assert len(pta.param_names) == 11
-
+    assert len(pta.param_names) == (13 if (psrTerm and not tie_psrTerm) else 11)
+    
     x0 = [param.sample() for param in pta.params]
     lnprior_fn = gwecc_prior(pta, tref, tref, name="gwecc")
     if np.isfinite(lnprior_fn(x0)):
@@ -199,10 +196,7 @@ def test_gwecc_target_block(psr, psrTerm, tie_psrTerm, spline):
 
     pta = PTA([model(psr)])
 
-    if psrTerm:
-        assert len(pta.param_names) == (10 if tie_psrTerm else 8)
-    else:
-        assert len(pta.param_names) == 8
+    assert len(pta.param_names) == (10 if (psrTerm and not tie_psrTerm) else 8)
 
     x0 = [param.sample() for param in pta.params]
     lnprior_fn = gwecc_target_prior(pta, gwdist, tref, tref, name="gwecc")

--- a/test/test_enterprise_gwecc.py
+++ b/test/test_enterprise_gwecc.py
@@ -73,7 +73,7 @@ def test_eccentric_pta_signal_1psr(psrTerm, spline):
 
 
 @pytest.mark.parametrize("psrTerm, spline", it.product([True, False], [True, False]))
-def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
+def test_eccentric_pta_signal(psrTerm, spline):
     res = eccentric_pta_signal(
         toas,
         theta,
@@ -94,7 +94,6 @@ def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
         tref,
         log10_A,
         psrTerm=psrTerm,
-        tie_psrTerm=tie_psrTerm,
         spline=spline,
     )
     assert np.all(np.isfinite(res))
@@ -104,7 +103,7 @@ def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
     "psrTerm, spline",
     it.product([True, False], [True, False]),
 )
-def test_eccentric_pta_signal_target(psrTerm, tie_psrTerm, spline):
+def test_eccentric_pta_signal_target(psrTerm, spline):
     res = eccentric_pta_signal_target(
         toas,
         theta,
@@ -125,7 +124,6 @@ def test_eccentric_pta_signal_target(psrTerm, tie_psrTerm, spline):
         log10_A,
         gwdist,
         psrTerm=psrTerm,
-        tie_psrTerm=tie_psrTerm,
         spline=spline,
     )
     assert np.all(np.isfinite(res))

--- a/test/test_enterprise_gwecc.py
+++ b/test/test_enterprise_gwecc.py
@@ -19,13 +19,10 @@ from enterprise_gwecc import (
     gwecc_target_prior,
 )
 
-
-@pytest.fixture()
-def psr():
-    testdatadir = pathlib.Path(__file__).resolve().parent / "testdata"
-    par = str(testdatadir / "J1909-3744_NANOGrav_12yv4.gls.par")
-    tim = str(testdatadir / "J1909-3744_NANOGrav_12yv4.tim")
-    return Pulsar(par, tim)
+testdatadir = pathlib.Path(__file__).resolve().parent / "testdata"
+par = str(testdatadir / "J1909-3744_NANOGrav_12yv4.gls.par")
+tim = str(testdatadir / "J1909-3744_NANOGrav_12yv4.tim")
+psr = Pulsar(par, tim)
 
 
 year = 365.25 * 24 * 3600
@@ -133,7 +130,7 @@ def test_eccentric_pta_signal_target(psrTerm, spline):
     "psrTerm, tie_psrTerm, spline",
     it.product([True, False], [True, False], [True, False]),
 )
-def test_gwecc_block(psr, psrTerm, tie_psrTerm, spline):
+def test_gwecc_block(psrTerm, tie_psrTerm, spline):
     tref = max(psr.toas)
 
     tm = MarginalizingTimingModel()
@@ -154,7 +151,7 @@ def test_gwecc_block(psr, psrTerm, tie_psrTerm, spline):
 
 
 @pytest.mark.parametrize("psrTerm, spline", it.product([True, False], [True, False]))
-def test_gwecc_1psr_block(psr, psrTerm, spline):
+def test_gwecc_1psr_block(psrTerm, spline):
     tref = max(psr.toas)
 
     tm = MarginalizingTimingModel()
@@ -178,7 +175,7 @@ def test_gwecc_1psr_block(psr, psrTerm, spline):
     "psrTerm, tie_psrTerm, spline",
     it.product([True, False], [True, False], [True, False]),
 )
-def test_gwecc_target_block(psr, psrTerm, tie_psrTerm, spline):
+def test_gwecc_target_block(psrTerm, tie_psrTerm, spline):
     tref = max(psr.toas)
 
     tm = MarginalizingTimingModel()

--- a/test/test_enterprise_gwecc.py
+++ b/test/test_enterprise_gwecc.py
@@ -72,10 +72,7 @@ def test_eccentric_pta_signal_1psr(psrTerm, spline):
     assert np.all(np.isfinite(res))
 
 
-@pytest.mark.parametrize(
-    "psrTerm, tie_psrTerm, spline",
-    it.product([True, False], [True, False], [True, False]),
-)
+@pytest.mark.parametrize("psrTerm, spline", it.product([True, False], [True, False]))
 def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
     res = eccentric_pta_signal(
         toas,
@@ -104,8 +101,8 @@ def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
 
 
 @pytest.mark.parametrize(
-    "psrTerm, tie_psrTerm, spline",
-    it.product([True, False], [True, False], [True, False]),
+    "psrTerm, spline",
+    it.product([True, False], [True, False]),
 )
 def test_eccentric_pta_signal_target(psrTerm, tie_psrTerm, spline):
     res = eccentric_pta_signal_target(
@@ -148,7 +145,10 @@ def test_gwecc_block(psr, psrTerm, tie_psrTerm, spline):
 
     pta = PTA([model(psr)])
 
-    assert len(pta.param_names) == (13 if psrTerm else 11)
+    if psrTerm:
+        assert len(pta.param_names) == (13 if tie_psrTerm else 11)
+    else:
+        assert len(pta.param_names) == 11
 
     x0 = [param.sample() for param in pta.params]
     lnprior_fn = gwecc_prior(pta, tref, tref, name="gwecc")
@@ -201,7 +201,10 @@ def test_gwecc_target_block(psr, psrTerm, tie_psrTerm, spline):
 
     pta = PTA([model(psr)])
 
-    assert len(pta.param_names) == (10 if psrTerm else 8)
+    if psrTerm:
+        assert len(pta.param_names) == (10 if tie_psrTerm else 8)
+    else:
+        assert len(pta.param_names) == 8
 
     x0 = [param.sample() for param in pta.params]
     lnprior_fn = gwecc_target_prior(pta, gwdist, tref, tref, name="gwecc")

--- a/test/test_enterprise_gwecc.py
+++ b/test/test_enterprise_gwecc.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import pathlib
+import itertools as it
 
 from enterprise.pulsar import Pulsar
 from enterprise.signals.gp_signals import MarginalizingTimingModel
@@ -51,9 +52,7 @@ log10_A = -9.0
 deltap = 100.0
 
 
-@pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
-)
+@pytest.mark.parametrize("psrTerm, spline", it.product([True, False], [True, False]))
 def test_eccentric_pta_signal_1psr(psrTerm, spline):
     res = eccentric_pta_signal_1psr(
         toas=toas,
@@ -74,9 +73,10 @@ def test_eccentric_pta_signal_1psr(psrTerm, spline):
 
 
 @pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
+    "psrTerm, tie_psrTerm, spline",
+    it.product([True, False], [True, False], [True, False]),
 )
-def test_eccentric_pta_signal(psrTerm, spline):
+def test_eccentric_pta_signal(psrTerm, tie_psrTerm, spline):
     res = eccentric_pta_signal(
         toas,
         theta,
@@ -97,15 +97,17 @@ def test_eccentric_pta_signal(psrTerm, spline):
         tref,
         log10_A,
         psrTerm=psrTerm,
+        tie_psrTerm=tie_psrTerm,
         spline=spline,
     )
     assert np.all(np.isfinite(res))
 
 
 @pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
+    "psrTerm, tie_psrTerm, spline",
+    it.product([True, False], [True, False], [True, False]),
 )
-def test_eccentric_pta_signal_target(psrTerm, spline):
+def test_eccentric_pta_signal_target(psrTerm, tie_psrTerm, spline):
     res = eccentric_pta_signal_target(
         toas,
         theta,
@@ -126,20 +128,22 @@ def test_eccentric_pta_signal_target(psrTerm, spline):
         log10_A,
         gwdist,
         psrTerm=psrTerm,
+        tie_psrTerm=tie_psrTerm,
         spline=spline,
     )
     assert np.all(np.isfinite(res))
 
 
 @pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
+    "psrTerm, tie_psrTerm, spline",
+    it.product([True, False], [True, False], [True, False]),
 )
-def test_gwecc_block(psr, psrTerm, spline):
+def test_gwecc_block(psr, psrTerm, tie_psrTerm, spline):
     tref = max(psr.toas)
 
     tm = MarginalizingTimingModel()
     wn = MeasurementNoise(efac=1.0)
-    wf = gwecc_block(tref=tref, psrTerm=psrTerm, spline=spline)
+    wf = gwecc_block(tref=tref, psrTerm=psrTerm, tie_psrTerm=tie_psrTerm, spline=spline)
     model = tm + wn + wf
 
     pta = PTA([model(psr)])
@@ -154,9 +158,7 @@ def test_gwecc_block(psr, psrTerm, spline):
         assert np.isfinite(pta.get_lnprior(x0))
 
 
-@pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
-)
+@pytest.mark.parametrize("psrTerm, spline", it.product([True, False], [True, False]))
 def test_gwecc_1psr_block(psr, psrTerm, spline):
     tref = max(psr.toas)
 
@@ -178,9 +180,10 @@ def test_gwecc_1psr_block(psr, psrTerm, spline):
 
 
 @pytest.mark.parametrize(
-    "psrTerm, spline", [(True, True), (True, False), (False, True), (False, False)]
+    "psrTerm, tie_psrTerm, spline",
+    it.product([True, False], [True, False], [True, False]),
 )
-def test_gwecc_target_block(psr, psrTerm, spline):
+def test_gwecc_target_block(psr, psrTerm, tie_psrTerm, spline):
     tref = max(psr.toas)
 
     tm = MarginalizingTimingModel()
@@ -191,6 +194,7 @@ def test_gwecc_target_block(psr, psrTerm, spline):
         gwphi=gwphi,
         gwdist=gwdist,
         psrTerm=psrTerm,
+        tie_psrTerm=tie_psrTerm,
         spline=spline,
     )
     model = tm + wn + wf


### PR DESCRIPTION
A new boolean option "tie_psrTerm" in the block functions to optionally tie the pulsar term phase to the Earth term phase.